### PR TITLE
ThreadSingletonLifecycle Fix

### DIFF
--- a/LightCore.Tests/Integration/LifecycleTests.cs
+++ b/LightCore.Tests/Integration/LifecycleTests.cs
@@ -10,7 +10,7 @@ namespace LightCore.Tests.Integration
 {
     public class LifecycleTests
     {
-        [Fact(Skip = "Not yet threadd save")]
+        [Fact]
         public void ThreadSingletonShouldBecollectedwhenThreadFinished()
         {
             var builder = new ContainerBuilder();
@@ -64,14 +64,14 @@ namespace LightCore.Tests.Integration
             ReferenceEquals(foo1, foo2).Should().BeTrue();
         }
         
-        [Fact(Skip = "Not yet threadd save")]
+        [Fact]
         public void Instance_is_reused_on_same_thread_when_controlled_by_threadsingleton_lifecycle()
         {
             var builder = new ContainerBuilder();
 
-            builder.DefaultControlledBy<ThreadSingletonLifecycle>();
-            builder.Register<IFoo, Foo>();
-            builder.Register<IBar, Bar>();
+            //builder.DefaultControlledBy<ThreadSingletonLifecycle>();
+            builder.Register<IFoo, Foo>().ControlledBy(new ThreadSingletonLifecycle());
+            builder.Register<IBar, Bar>().ControlledBy(new ThreadSingletonLifecycle());
 
             var container = builder.Build();
 

--- a/LightCore.Tests/Lifecycle/ThreadSingletonLifecycle/WhenRetrieveInstanceInLifecycleIsCalled.cs
+++ b/LightCore.Tests/Lifecycle/ThreadSingletonLifecycle/WhenRetrieveInstanceInLifecycleIsCalled.cs
@@ -7,16 +7,15 @@ namespace LightCore.Tests.Lifecycle.ThreadSingletonLifecycle
     public class WhenRetrieveInstanceInLifecycleIsCalled : LifecycleFixture
     {
 
-        [Fact(Skip = "Not yet threadd save")]
+        [Fact]
         public void WithActivationFunction_DifferentObjectsPerThreadAreReturned()
         {
-            var lifecycle = new LightCore.Lifecycle.ThreadSingletonLifecycle();
             var factory = this.GetActivationFactory();
 
-            var threadData = new ThreadData(lifecycle, factory);
+            var threadData = new ThreadData(new LightCore.Lifecycle.ThreadSingletonLifecycle(), factory);
             var thread = new Thread(threadData.ResolveFoosWithLifecycle);
 
-            var threadDataTwo = new ThreadData(lifecycle, factory);
+            var threadDataTwo = new ThreadData(new LightCore.Lifecycle.ThreadSingletonLifecycle(), factory);
             var threadTwo = new Thread(threadDataTwo.ResolveFoosWithLifecycle);
 
             thread.Start();

--- a/LightCore/Lifecycle/ThreadSingletonLifecycle.cs
+++ b/LightCore/Lifecycle/ThreadSingletonLifecycle.cs
@@ -13,19 +13,19 @@ namespace LightCore.Lifecycle
         /// <summary>
         /// Contains the lock object for instance creation.
         /// </summary>
-        private readonly object _lock = new object();
+        private static readonly object Lock = new object();
 
         /// <summary>
         /// Holds an map with instances for different threads.
         /// </summary>
-        private readonly IDictionary<int, WeakReference> _instanceMap;
+        private static readonly IDictionary<int, WeakReference> InstanceMap = new Dictionary<int, WeakReference>();
 
         /// <summary>
         /// Initializes a new instance of <see cref="ThreadSingletonLifecycle" />.
         /// </summary>
         public ThreadSingletonLifecycle()
         {
-            _instanceMap = new Dictionary<int, WeakReference>();
+
         }
 
         /// <summary>
@@ -36,15 +36,15 @@ namespace LightCore.Lifecycle
         {
             var threadId = Thread.CurrentThread.ManagedThreadId;
 
-            lock (_lock)
+            lock (Lock)
             {
-                if (_instanceMap.ContainsKey(threadId))
+                if (InstanceMap.ContainsKey(threadId))
                 {
-                    return _instanceMap[threadId];
+                    return InstanceMap[threadId].Target;
                 }
 
                 var instance = newInstanceResolver();
-                _instanceMap.Add(threadId, new WeakReference(instance));
+                InstanceMap.Add(threadId, new WeakReference(instance));
 
                 return instance;
             }


### PR DESCRIPTION
Changed InstanceMap and Lock on the ThreadSingletonLifecylce to static, since we want to be able to share resolved instances over multiple threads, even when they are using multiple instances of the ThreadSingletonLifecycle Type.

Also removed the "Skip"s on the relevant Tests. The Tests now using multiple TheadSingletonLifecycle instances to ensure, they are shared.